### PR TITLE
Saving and loading macros in web interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,6 +65,10 @@
                 <h3>Share</h3>
                 <input type="text" id="share_link" readonly>
             </form>
+            <h3>Macros</h3>
+            Save Macros: <button id='download_macros'>Download</button>
+            <br>
+            Upload Macros: <input type="file" id="upload_macros">
         </div>
         <button id="show_options">⚙︎</button>
 


### PR DESCRIPTION
Added buttons to the side menu for saving and loading macro definitions. Macros are saved as a .txt file, one definition per line. Macros are loaded from files in the same format (must have the special symbols not backslash/equals, each definition separated by newline). Please let me know if there's anything I overlooked/what changes are needed.

<img width="800" alt="screen shot 2018-12-22 at 9 43 30 pm" src="https://user-images.githubusercontent.com/18299205/50381100-ad788900-0632-11e9-8482-ea706cf458d3.png">
